### PR TITLE
fix : 서버접속 라이선스 아니여도 cal key 조회되는 오류 수정 완료

### DIFF
--- a/src/main/java/com/kbds/itamserveradmin/domain/contract/controller/ContractController.java
+++ b/src/main/java/com/kbds/itamserveradmin/domain/contract/controller/ContractController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
+import static com.kbds.itamserveradmin.global.exception.ErrorCode.CONTRACT_IS_NOT_CAL_LIC;
 import static com.kbds.itamserveradmin.global.exception.ErrorCode.PASSWORD_INCORRECT;
 import static org.springframework.http.ResponseEntity.ok;
 
@@ -34,14 +35,19 @@ public class ContractController {
             @PathVariable(name = "contId") String contId,
             @RequestBody PasswordReq pwReq,
             @RequestHeader String userId) {
+
         final String correctPw = "1234";
 
-        if (correctPw.equals(pwReq.getPw())) {
-            CalKeyRes calKey = contractService.getCalKey(userId, contId);
-            return ResponseEntity.ok(calKey);
-        } else {
+        if (!correctPw.equals(pwReq.getPw())) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(PASSWORD_INCORRECT);
         }
+
+        CalKeyRes calKey = contractService.getCalKey(userId, contId);
+        if (calKey == null) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(CONTRACT_IS_NOT_CAL_LIC);
+        }
+        return ResponseEntity.ok(calKey);
+
 
     }
 }

--- a/src/main/java/com/kbds/itamserveradmin/domain/contract/service/ContractService.java
+++ b/src/main/java/com/kbds/itamserveradmin/domain/contract/service/ContractService.java
@@ -1,6 +1,5 @@
 package com.kbds.itamserveradmin.domain.contract.service;
 
-import com.kbds.itamserveradmin.domain.assetRequest.entity.AssetRequest;
 import com.kbds.itamserveradmin.domain.assetRequest.entity.UserAssetRequestInfo;
 import com.kbds.itamserveradmin.domain.assetRequest.repository.AssetRequestRepository;
 import com.kbds.itamserveradmin.domain.assetRequest.repository.UserAssetRequestInfoRepository;
@@ -12,10 +11,8 @@ import com.kbds.itamserveradmin.domain.contract.repository.ContractRepository;
 import com.kbds.itamserveradmin.domain.contract.repository.NumOfUsersTypeRepository;
 import com.kbds.itamserveradmin.domain.contract.repository.PeriodTypeRepository;
 import com.kbds.itamserveradmin.domain.contract.repository.SupplyTypeRepository;
-import com.kbds.itamserveradmin.domain.purchaseRequest.entity.NewAssetRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,7 +31,6 @@ public class ContractService {
     private final SupplyTypeRepository supplyTypeRepository;
     private final PeriodTypeRepository periodTypeRepository;
     private final NumOfUsersTypeRepository numOfUsersTypeRepository;
-    private final AssetRequestRepository assetRequestRepository;
     private final UserAssetRequestInfoRepository userAssetRequestInfoRepository;
 
     private final AssetRequestService assetRequestService;
@@ -166,6 +162,13 @@ public class ContractService {
     }
 
     public CalKeyRes getCalKey(String userId, String contId) {
+        Contract findContract =  contractRepository.findById(contId)
+                .orElseThrow(() -> new IllegalArgumentException(String.valueOf(CONTRACT_NOT_FOUND)));
+        
+        // 해당 계약의 라이선스 조합이 서버접속이 아닌 경우 -> Exception 던지기
+        if (findContract.getContLicTag().charAt(2) != '5') {
+            return null;
+        }
         String astReqId = assetRequestService.getAstReqIdByUserIdAndContId(userId, contId);
         UserAssetRequestInfo userAstReqInfo = userAssetRequestInfoRepository.findByAssetRequest_AstReqId(astReqId);
 

--- a/src/main/java/com/kbds/itamserveradmin/global/exception/ErrorCode.java
+++ b/src/main/java/com/kbds/itamserveradmin/global/exception/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
     // contract
     CONTRACT_RECORD_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "C-001", "활동 기록 타입을 찾을 수 없습니다."),
     CONTRACT_NOT_FOUND(HttpStatus.NOT_FOUND, "C-002", "해당 계약을 찾을 수 없습니다."),
-    
+    CONTRACT_IS_NOT_CAL_LIC(HttpStatus.FORBIDDEN, "C-003", "해당 계약은 cal 라이선스가 아닙니다."),
+
     //기타
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "I-001", "내부 에러가 발생했습니다."),
 


### PR DESCRIPTION
## 👾 작업 내용
- 해당 계약이 서버접속 라이선스인 경우에만 cal key 조회 가능하도록 수정 완료

<br>

## 📸 스크린샷

<br>

## 🎸 기타 사항
- 
