### PR TITLE
Feat/contract

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,11 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
 
 
 	//h2 DB

--- a/src/main/java/com/kbds/itamserveradmin/domain/contract/controller/ContractController.java
+++ b/src/main/java/com/kbds/itamserveradmin/domain/contract/controller/ContractController.java
@@ -4,12 +4,18 @@ import com.kbds.itamserveradmin.domain.contract.dto.CalKeyRes;
 import com.kbds.itamserveradmin.domain.contract.dto.ContExpireRes;
 import com.kbds.itamserveradmin.domain.contract.dto.DashBoardRes;
 import com.kbds.itamserveradmin.domain.contract.dto.PasswordReq;
+import com.kbds.itamserveradmin.domain.contract.dto.request.NumberOfUsersReq;
+import com.kbds.itamserveradmin.domain.contract.dto.request.PeriodLicenseReq;
+import com.kbds.itamserveradmin.domain.contract.dto.request.SupplyLicense;
+import com.kbds.itamserveradmin.domain.contract.dto.request.RegisterContractReq;
 import com.kbds.itamserveradmin.domain.contract.service.ContractService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 import static com.kbds.itamserveradmin.global.exception.ErrorCode.*;
 import static org.springframework.http.ResponseEntity.ok;
@@ -89,18 +95,68 @@ public class ContractController {
         }
     }
 
-    // 계약 등록
-    @PostMapping("/kbitam")
+    // 계약 등록 (요청 없이)
+    @PostMapping("/kbitam/")
     public ResponseEntity<?> registerContract(
-
+            @RequestHeader String userId,
+            @RequestBody @Valid RegisterContractReq registerContractReq
     )
     {
-        return null;
+        contractService.registerContract(userId, registerContractReq);
+        return ResponseEntity.ok("Successfully registered contract!");
+    }
+
+    // 라이센스 공급형태
+    @PostMapping("/kbitam/supply/{contractId}")
+    public ResponseEntity<?> registerSupplyLicense(
+            @RequestHeader String userId,
+            @PathVariable String contractId,
+            @RequestBody @Valid SupplyLicense supplyLicense
+    )
+    {
+        contractService.registerSupplyLicense(userId, contractId, supplyLicense);
+        return ResponseEntity.ok("Successfully registered contract!");
+    }
+
+    // 라이센스 기간
+    @PostMapping("/kbitam/period/{contractId}")
+    public ResponseEntity<?> registerPeriodLicense(
+            @RequestHeader String userId,
+            @PathVariable String contractId,
+            @RequestBody @Valid PeriodLicenseReq periodLicenseReq
+    )
+    {
+        contractService.registerPeriodLicense(userId, contractId, periodLicenseReq);
+        return ResponseEntity.ok("Successfully registered contract!");
+    }
+
+    // 라이센스 사용자 수
+    @PostMapping("/kbitam/numbers/{contractId}")
+    public ResponseEntity<?> registerNumberOfUsersLicense(
+            @RequestHeader String userId,
+            @PathVariable String contractId,
+            @RequestBody @Valid NumberOfUsersReq numberOfUsersReq
+    )
+    {
+        contractService.registerNumberOfUsersLicense(userId, contractId, numberOfUsersReq);
+        return ResponseEntity.ok("Successfully registered contract!");
     }
 
     // 계약 등록 (요청 ID)
-    @PostMapping("/kbitam")
+    @PostMapping("/kbitam/{newAssetRequestId}")
     public ResponseEntity<?> registerContractByRequest(
+            @RequestHeader String userId,
+            @PathVariable String newAssetRequestId,
+            @RequestBody @Valid RegisterContractReq registerContractReq
+    )
+    {
+        contractService.registerContractByRequest(userId, newAssetRequestId, registerContractReq);
+        return ResponseEntity.ok("Successfully registered contract!");
+    }
+
+    // 계약대상 자산 조회
+    @GetMapping("/kbitam/assets")
+    public ResponseEntity<?> getAssets(
 
     )
     {
@@ -134,6 +190,4 @@ public class ContractController {
 
         return null;
     }
-
-
 }

--- a/src/main/java/com/kbds/itamserveradmin/domain/contract/controller/ContractController.java
+++ b/src/main/java/com/kbds/itamserveradmin/domain/contract/controller/ContractController.java
@@ -89,5 +89,51 @@ public class ContractController {
         }
     }
 
+    // 계약 등록
+    @PostMapping("/kbitam")
+    public ResponseEntity<?> registerContract(
+
+    )
+    {
+        return null;
+    }
+
+    // 계약 등록 (요청 ID)
+    @PostMapping("/kbitam")
+    public ResponseEntity<?> registerContractByRequest(
+
+    )
+    {
+        return null;
+    }
+
+    // 계약업체 조회
+    @GetMapping("/kbitam/corporations")
+    public ResponseEntity<?> getCorporation(
+
+    )
+    {
+        return null;
+    }
+
+    // 계약 조회
+    @GetMapping("/kbitam")
+    public ResponseEntity<?> getContract(
+
+    )
+    {
+        return null;
+    }
+
+    // 계약 조회
+    @PatchMapping("/kbitam/{contractId}")
+    public ResponseEntity<?> updateContract(
+            @PathVariable Long contractId
+    )
+    {
+
+        return null;
+    }
+
 
 }

--- a/src/main/java/com/kbds/itamserveradmin/domain/contract/dto/request/NumberOfUsersReq.java
+++ b/src/main/java/com/kbds/itamserveradmin/domain/contract/dto/request/NumberOfUsersReq.java
@@ -1,0 +1,18 @@
+package com.kbds.itamserveradmin.domain.contract.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class NumberOfUsersReq {
+    private int currentCPU;
+    private int currentUsers;
+    private String ipRange;
+    private int maxCPULimit;
+    private int maxUsersLimit;
+    private int totalCal;
+    private int totalNumPur;
+    private int totalServer;
+    private String numOfUsersId;
+    private int currentCore;
+    private int maxCoreLimit;
+}

--- a/src/main/java/com/kbds/itamserveradmin/domain/contract/dto/request/PeriodLicenseReq.java
+++ b/src/main/java/com/kbds/itamserveradmin/domain/contract/dto/request/PeriodLicenseReq.java
@@ -1,0 +1,9 @@
+package com.kbds.itamserveradmin.domain.contract.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class PeriodLicenseReq {
+    private String startDate;
+    private String endDate;
+}

--- a/src/main/java/com/kbds/itamserveradmin/domain/contract/dto/request/RegisterContractReq.java
+++ b/src/main/java/com/kbds/itamserveradmin/domain/contract/dto/request/RegisterContractReq.java
@@ -1,0 +1,42 @@
+package com.kbds.itamserveradmin.domain.contract.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class RegisterContractReq {
+
+    @Schema(type = "String", description = "계약명", example = "TV Calibration Software", required = true)
+    @NotBlank(message = "C0001")
+    private String contractName;
+
+    @Schema(type = "String", description = "계약 대상 자산", example = "1", required = true)
+    @NotBlank(message = "C0001")
+    private String assetId;
+
+    @Schema(type = "String", description = "계약 업체", example = "1", required = true)
+    @NotBlank(message = "C0001")
+    private String corporationId;
+
+    @Schema(type = "String", description = "계약 담당자", example = "김민기", required = true)
+    @NotBlank(message = "C0001")
+    private String contractAdminName;
+
+    @Schema(type = "String", description = "가격", example = "46,787,027.7931", required = true)
+    @NotBlank(message = "C0001")
+    private int contractPrice;
+
+    @Schema(type = "String", description = "시작일", example = "2022-09-25", required = true)
+    @NotBlank(message = "C0001")
+    private String startDate;
+
+    @Schema(type = "String", description = "종료일", example = "2024-09-25", required = true)
+    @NotBlank(message = "C0001")
+    private String endDate;
+
+    @Schema(type = "String", description = "기타사항", example = "2022-09-25 등록", required = true)
+    @NotBlank(message = "C0001")
+    private String description;
+}

--- a/src/main/java/com/kbds/itamserveradmin/domain/contract/dto/request/SupplyLicense.java
+++ b/src/main/java/com/kbds/itamserveradmin/domain/contract/dto/request/SupplyLicense.java
@@ -1,0 +1,12 @@
+package com.kbds.itamserveradmin.domain.contract.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class SupplyLicense {
+    private String acsUrl;
+    private String supplyInstallFile;
+    private String supplyInstallGuide;
+    private String supplyUserGuide;
+    private String supplyVersion;
+}

--- a/src/main/java/com/kbds/itamserveradmin/domain/contract/entity/Contract.java
+++ b/src/main/java/com/kbds/itamserveradmin/domain/contract/entity/Contract.java
@@ -1,6 +1,7 @@
 package com.kbds.itamserveradmin.domain.contract.entity;
 
 import com.kbds.itamserveradmin.domain.asset.entity.Asset;
+import com.kbds.itamserveradmin.domain.contract.dto.request.RegisterContractReq;
 import com.kbds.itamserveradmin.domain.corporation.entity.Corporation;
 import com.kbds.itamserveradmin.domain.purchaseRequest.entity.NewAssetRequest;
 import com.kbds.itamserveradmin.domain.user.entity.User;
@@ -57,4 +58,19 @@ public class Contract {
         contRegDate = now;
     }
 
+    public static Contract toEntity(RegisterContractReq registerContractReq, Asset ast, Corporation corp, User user) {
+        return Contract.builder()
+                .ast(ast)
+                .corp(corp)
+                .user(user)
+                .contName(registerContractReq.getContractName())
+                .contPrice(registerContractReq.getContractPrice())
+                .contAdminName(registerContractReq.getContractAdminName())
+                .contOpStatus(OpStatus.IN_OPERATION)
+                .build();
+    }
+
+    public void toUpdateNewAssetRequest(NewAssetRequest newAstReq) {
+        this.newAstReq = newAstReq;
+    }
 }

--- a/src/main/java/com/kbds/itamserveradmin/domain/contract/entity/ContractType.java
+++ b/src/main/java/com/kbds/itamserveradmin/domain/contract/entity/ContractType.java
@@ -1,0 +1,23 @@
+package com.kbds.itamserveradmin.domain.contract.entity;
+
+import com.kbds.itamserveradmin.global.exception.BaseException;
+import com.kbds.itamserveradmin.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum ContractType {
+    LICENSE_SUPPLY("라이선스 공급형태"),
+    LICENSE_PERIOD("라이선스 기간"),
+    NUMBER_OF_USERS("라이선스 사용자 수");
+    private final String value;
+
+    public static ContractType getContractTypeByName(String value) {
+        return Arrays.stream(ContractType.values())
+                .filter(r -> r.getValue().equals(value))
+                .findAny().orElseThrow(() -> new BaseException(ErrorCode.CONTRACT_TYPE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/kbds/itamserveradmin/domain/contract/entity/NumOfUsersType.java
+++ b/src/main/java/com/kbds/itamserveradmin/domain/contract/entity/NumOfUsersType.java
@@ -1,5 +1,6 @@
 package com.kbds.itamserveradmin.domain.contract.entity;
 
+import com.kbds.itamserveradmin.domain.contract.dto.request.NumberOfUsersReq;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -32,4 +33,18 @@ public class NumOfUsersType {
     private Integer totalNumPur;
     private Integer totalServer;
     private Integer totalCal;
+
+    public static NumOfUsersType toEntity(Contract contract, NumberOfUsersReq numberOfUsersReq) {
+        return NumOfUsersType.builder()
+                .cont(contract)
+                .maxUsersLimit(numberOfUsersReq.getMaxUsersLimit())
+                .maxCoreLimit(numberOfUsersReq.getMaxCoreLimit())
+                .ipRange(numberOfUsersReq.getIpRange())
+                .currUsers(numberOfUsersReq.getCurrentUsers())
+                .currCore(numberOfUsersReq.getCurrentCore())
+                .totalNumPur(numberOfUsersReq.getTotalNumPur())
+                .totalServer(numberOfUsersReq.getTotalServer())
+                .totalCal(numberOfUsersReq.getTotalCal())
+                .build();
+    }
 }

--- a/src/main/java/com/kbds/itamserveradmin/domain/contract/entity/PeriodType.java
+++ b/src/main/java/com/kbds/itamserveradmin/domain/contract/entity/PeriodType.java
@@ -1,5 +1,7 @@
 package com.kbds.itamserveradmin.domain.contract.entity;
 
+import com.kbds.itamserveradmin.domain.contract.dto.request.PeriodLicenseReq;
+import com.kbds.itamserveradmin.global.utils.DateTimeUtil;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -27,4 +29,12 @@ public class PeriodType {
     private LocalDateTime contStartDate;
 
     private LocalDateTime contEndDate;
+
+    public static PeriodType toEntity(Contract contract, PeriodLicenseReq periodLicenseReq) {
+        return PeriodType.builder()
+                .cont(contract)
+                .contStartDate(DateTimeUtil.stringToLocalDate(periodLicenseReq.getStartDate()))
+                .contEndDate(DateTimeUtil.stringToLocalDate(periodLicenseReq.getEndDate()))
+                .build();
+    }
 }

--- a/src/main/java/com/kbds/itamserveradmin/domain/contract/entity/SupplyType.java
+++ b/src/main/java/com/kbds/itamserveradmin/domain/contract/entity/SupplyType.java
@@ -1,5 +1,5 @@
 package com.kbds.itamserveradmin.domain.contract.entity;
-import com.kbds.itamserveradmin.domain.contract.entity.Contract;
+import com.kbds.itamserveradmin.domain.contract.dto.request.SupplyLicense;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -29,4 +29,15 @@ public class SupplyType {
     private String acsUrl;
     private String splyVer;
     private String splyUserGuide;
+
+    public static SupplyType toEntity(Contract contract, SupplyLicense licenseSupplyReq) {
+        return SupplyType.builder()
+                .cont(contract)
+                .splyInstallFile(licenseSupplyReq.getSupplyInstallFile())
+                .splyInstallGuide(licenseSupplyReq.getSupplyInstallGuide())
+                .acsUrl(licenseSupplyReq.getAcsUrl())
+                .splyVer(licenseSupplyReq.getSupplyVersion())
+                .splyUserGuide(licenseSupplyReq.getSupplyUserGuide())
+                .build();
+    }
 }

--- a/src/main/java/com/kbds/itamserveradmin/global/config/SwaggerConfig.java
+++ b/src/main/java/com/kbds/itamserveradmin/global/config/SwaggerConfig.java
@@ -30,7 +30,7 @@ public class SwaggerConfig {
                 .useDefaultResponseMessages(true)
                 .apiInfo(apiInfo())
                 .select()
-                .apis(RequestHandlerSelectors.basePackage("com.kbitam.api"))
+                .apis(RequestHandlerSelectors.basePackage("kbdsitamserveradmin"))
                 .paths(PathSelectors.any())
                 .build();
     }

--- a/src/main/java/com/kbds/itamserveradmin/global/exception/ErrorCode.java
+++ b/src/main/java/com/kbds/itamserveradmin/global/exception/ErrorCode.java
@@ -14,6 +14,10 @@ public enum ErrorCode {
     CONTRACT_RECORD_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "C-001", "활동 기록 타입을 찾을 수 없습니다."),
     CONTRACT_NOT_FOUND(HttpStatus.NOT_FOUND, "C-002", "해당 계약을 찾을 수 없습니다."),
     CONTRACT_IS_NOT_CAL_LIC(HttpStatus.FORBIDDEN, "C-003", "해당 계약은 cal 라이선스가 아닙니다."),
+    CONTRACT_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "C-004", "계약 종류(공급형태, 기간, 사용자수)를 찾을 수 없습니다."),
+
+    // corporation
+    CORPORATION_NOT_FOUND(HttpStatus.NOT_FOUND, "P-001", "id에 해당하는 업체가 존재하지 않습니다."),
 
     //기타
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "I-001", "내부 에러가 발생했습니다."),
@@ -23,9 +27,16 @@ public enum ErrorCode {
 
     // asset
     ASSET_IS_NOT_INUSE(HttpStatus.CONFLICT, "A-001", "사용중인 상태가 아닙니다."),
-    ASSET_IS_EXPIRE(HttpStatus.FORBIDDEN, "A-002", "사용이 만료되었습니다.");
+    ASSET_IS_EXPIRE(HttpStatus.FORBIDDEN, "A-002", "사용이 만료되었습니다."),
+    ASSET_NOT_FOUND(HttpStatus.NOT_FOUND, "A-003", "id에 일치하는 자산을 찾을 수 없습니다."),
 
-    
+    // new asset
+    NEW_ASSET_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "N-001", "id에 일치하는 자산 요청 기록을 찾을 수 없습니다."),
+
+    // user
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U-001", "id에 일치하는 유저를 찾을 수 없습니다.");
+
+
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/kbds/itamserveradmin/global/utils/DateTimeUtil.java
+++ b/src/main/java/com/kbds/itamserveradmin/global/utils/DateTimeUtil.java
@@ -1,0 +1,13 @@
+package com.kbds.itamserveradmin.global.utils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class DateTimeUtil {
+
+    // string(YYYY-MM-DD) -> localDateTime
+    public static LocalDateTime stringToLocalDate(String stringDate) {
+        return LocalDateTime.parse(stringDate, DateTimeFormatter.ISO_DATE_TIME);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,9 +16,9 @@ spring:
 
   datasource:
     platform: mysql
-    url: jdbc:mysql://localhost:3306/kbds?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:3306/KBDS_ITAM?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
-    password: 1234
+    password: 123456789
     driver-class-name: com.mysql.cj.jdbc.Driver # mysql 8버전
 
 


### PR DESCRIPTION
## 👾 작업 내용
- 요청(newAssetRequest)없는 계약 등록 (registerContract) API 기능구현
- 라이센스 공급형태 타입 계약 등록 API 기능 구현
- 라이센스 기간 타입 계약 등록 API 기능 구현
- 라이센스 사용자수 타입 계약 등록 API 기능 구현
- 요청(newAssetRequest)에 따른 계약 등록 API 기능 구현

<br>

## 📸 스크린샷

<br>

## 🎸 기타 사항
- 1차로 공급형태, 기간, 사용자수 타입에 대한 계약 등록을 하나의 API로 구현 시도해봤으나, 한 API의 책임이 너무 큰것같아 분리했습니다 (공급형태, 기간, 사용자수)
